### PR TITLE
Move Env and EnvTrait from equip/framework to equip/config

### DIFF
--- a/src/Configuration/EnvTrait.php
+++ b/src/Configuration/EnvTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Equip\Configuration;
+
+use Equip\Env;
+
+trait EnvTrait
+{
+    /**
+     * @var Env
+     */
+    private $env;
+
+    /**
+     * @param Env $env
+     */
+    public function __construct(Env $env)
+    {
+        $this->env = $env;
+    }
+}

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Equip;
+
+use Equip\Structure\Dictionary;
+
+class Env extends Dictionary
+{
+}


### PR DESCRIPTION
As [discussed](https://github.com/wheniwork/api-configuration/pull/16#issuecomment-229994404) in wheniwork/api-configuration#16, in order to have `api-configuration` depend only on `equip/config`, Env and EnvTrait must be moved over to this repo.
